### PR TITLE
feat: Add personalized post feed for followed users

### DIFF
--- a/apps/devlog-backend/src/posts/posts.controller.ts
+++ b/apps/devlog-backend/src/posts/posts.controller.ts
@@ -32,10 +32,21 @@ import {
 } from './dto/publish-response.dto';
 import { PostQueryDto } from './dto/post-query.dto';
 import type { Request } from 'express';
+import { SuccessResponseDto } from 'src/common/dto/responses/success-response.dto';
 
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @ApiAuthenticatedEndpoint('Get following posts', 200, SuccessResponseDto)
+  @Get('feed')
+  getFollowingPosts(
+    @GetUser('id') userId: string,
+    @Query() paginatedQueryDto: PaginationQueryDto,
+  ) {
+    return this.postsService.getFollowingPosts(userId, paginatedQueryDto);
+  }
 
   @UseGuards(JwtAuthGuard)
   @ResponseMessage('Draft created successfully')

--- a/apps/devlog-backend/src/posts/posts.module.ts
+++ b/apps/devlog-backend/src/posts/posts.module.ts
@@ -7,9 +7,10 @@ import { Category } from '../categories/entities/category.entity';
 import { User } from '../users/entities/user.entity';
 import { ViewTrackerService } from './view-tracker.service';
 import { PostView } from './entities/post-view.entity';
+import { Follow } from 'src/follows/entities/follow.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Post, Category, User, PostView])],
+  imports: [TypeOrmModule.forFeature([Post, Category, User, PostView,Follow])],
   providers: [PostsService, ViewTrackerService],
   controllers: [PostsController],
 })

--- a/apps/devlog-backend/src/posts/posts.service.ts
+++ b/apps/devlog-backend/src/posts/posts.service.ts
@@ -5,15 +5,16 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { In, Repository } from 'typeorm';
-import { Post, PostStatus } from './entities/post.entity';
-import { CreatePostDto } from './dto/create-post.dto';
-import { Category } from '../categories/entities/category.entity';
-import { User } from 'src/users/entities/user.entity';
-import { CreatePublishPostDto } from './dto/publish-post.dto';
-import { generateSlug } from 'src/common/utils/slug.util';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
+import { generateSlug } from 'src/common/utils/slug.util';
+import { Follow } from 'src/follows/entities/follow.entity';
+import { User } from 'src/users/entities/user.entity';
+import { In, Repository } from 'typeorm';
+import { Category } from '../categories/entities/category.entity';
+import { CreatePostDto } from './dto/create-post.dto';
 import { PostQueryDto } from './dto/post-query.dto';
+import { CreatePublishPostDto } from './dto/publish-post.dto';
+import { Post, PostStatus } from './entities/post.entity';
 import { ViewTrackerService } from './view-tracker.service';
 
 @Injectable()
@@ -24,7 +25,9 @@ export class PostsService {
     private readonly categoryRepository: Repository<Category>,
     private readonly viewTrackerService: ViewTrackerService,
     @InjectRepository(User) private readonly userRepository: Repository<User>,
-  ) {}
+    @InjectRepository(Follow)
+    private readonly followReposity: Repository<Follow>,
+  ) { }
 
   async createDraft(user: User) {
     const draft = this.postRepository.create({
@@ -484,5 +487,69 @@ export class PostsService {
     return {
       post,
     };
+  }
+
+  async getFollowingPosts(
+    userId: string,
+    paginatedQueryDto: PaginationQueryDto,
+  ) {
+    const { limit = 10, page = 1 } = paginatedQueryDto;
+    const skip = (page - 1) * limit;
+    const user = await this.userRepository.findOne({
+      where: {
+        id: userId,
+      },
+    });
+
+    if (!user) throw new NotFoundException('User not found');
+
+    const follow = await this.followReposity.find({
+      where: {
+        follower: {
+          id: userId,
+        },
+      },
+      relations: ['following'],
+    });
+
+    const followingUserIds = follow?.map((user) => user?.following?.id);
+
+    if (!followingUserIds?.length) {
+      return {
+        items: [],
+        meta: {
+          currentPage: page,
+          totalItems: 0,
+          totalPages: 0,
+          hasPreviousPage: false,
+          hasNextPage: false,
+        },
+      };
+    }
+    const queryBuilder = this.postRepository
+      .createQueryBuilder('post')
+      .leftJoin('post.author', 'author')
+      .addSelect(['author.id', 'author.displayName', 'author.avatar'])
+      .where('post.status = :status', { status: PostStatus.PUBLISHED })
+      .andWhere('post.authorId IN (:...followingUserIds)', {
+        followingUserIds,
+      })
+      .skip(skip)
+      .take(limit);
+
+    const [items, totalItems] = await queryBuilder.getManyAndCount();
+    const totalPages = Math.ceil(totalItems / limit);
+    const res = {
+      items,
+      meta: {
+        currentPage: page,
+        itemsPerPage: limit,
+        totalItems,
+        totalPages,
+        hasPreviousPage: page > 1,
+        hasNextPage: page < totalPages,
+      },
+    };
+    return res;
   }
 }


### PR DESCRIPTION

## Description

This pull request introduces a new API endpoint `GET /posts/feed` that provides a personalized feed of posts from users that the authenticated user follows.

- **New Endpoint:** `GET /posts/feed` for fetching a paginated feed of posts from followed users.
- **Service Logic:** Implemented `getFollowingPosts` in `PostsService` to handle the business logic of fetching the feed.


## Testing Steps

1.  Run the backend application.
2.  Authenticate as a user who is following other users.
3.  Make a `GET` request to the `/posts/feed` endpoint.
4.  Verify that the response contains a paginated list of posts from the users you are following.

---

## Checklist

- [x] I have run the application to ensure my changes work as expected.
- [ ] I have added tests where applicable.
- [ ] I have included screenshots or recordings of any UI changes.
- [x] I have included all necessary references to tickets, issues, or conversations.
- [x] This PR is ready for review and meets the contribution guidelines.
