### PR TITLE
fix(frontend): correct Toaster component recursion

### DIFF
--- a/apps/frontend/src/components/ui/toaster.tsx
+++ b/apps/frontend/src/components/ui/toaster.tsx
@@ -17,7 +17,7 @@ export function Toaster() {
     <ToastProvider>
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
-          <Toaster key={id} {...props}>
+          <Toast key={id} {...props}>
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
               {description && (
@@ -26,7 +26,7 @@ export function Toaster() {
             </div>
             {action}
             <ToastClose />
-          </Toaster>
+          </Toast>
         );
       })}
       <ToastViewport />


### PR DESCRIPTION
This commit fixes a bug in the `Toaster` component where it was recursively calling itself instead of using the `Toast` component. This caused an infinite loop and prevented toasts from being displayed correctly. The `Toaster` has been corrected to properly render `Toast` components, ensuring that notifications are displayed as expected.