### PR TITLE
chore(backend): add staging URL to CORS allowed origins

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -79,7 +79,11 @@ async function bootstrap() {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
       if (!origin) return callback(null, true);
 
-      const allowedOrigins = ['http://localhost:3000', 'http://127.0.0.1:3000'];
+      const allowedOrigins = [
+        'http://localhost:3000',
+        'http://127.0.0.1:3000',
+        'https://devlog-staging.vercel.app/',
+      ];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       if (allowedOrigins.includes(origin)) {


### PR DESCRIPTION
This commit updates the CORS configuration to include the staging frontend URL (`https://devlog-staging.vercel.app/`) in the list of allowed origins. This change is necessary to allow the staging environment to communicate with the backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved CORS errors when accessing the app from the staging environment.

* **Chores**
  * Expanded the backend CORS allowlist to include the staging domain, enabling the staging web app to interact with the API without cross-origin blocks.
  * Improves reliability of authentication and API requests from staging, ensuring smoother previews and testing with no changes required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->