### PR TITLE
chore(backend): update CORS configuration for staging URL and increase max age

### DIFF
--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -82,7 +82,7 @@ async function bootstrap() {
       const allowedOrigins = [
         'http://localhost:3000',
         'http://127.0.0.1:3000',
-        'https://devlog-staging.vercel.app/',
+        'https://devlog-staging.vercel.app',
       ];
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
@@ -97,7 +97,7 @@ async function bootstrap() {
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
     credentials: true,
     allowedHeaders: 'Content-Type, Authorization',
-    maxAge: 600,
+    maxAge: 86400,
   });
 
   await app.listen(process.env.PORT ?? 8080);


### PR DESCRIPTION
This commit modifies the CORS settings by removing the trailing slash from the staging URL and increasing the max age for preflight requests from 600 to 86400 seconds, enhancing the backend's handling of CORS requests.

